### PR TITLE
Add curriculum maintenance scaffolding (quarterly review, PR/issue te…

### DIFF
--- a/.github/ISSUE_TEMPLATE/content_bug.md
+++ b/.github/ISSUE_TEMPLATE/content_bug.md
@@ -1,0 +1,17 @@
+---
+name: Content Bug
+labels: content-bug
+about: Something is wrong or outdated in slides/notes/code
+---
+
+## Problem
+What’s broken/outdated?
+
+## Where
+File/Slide link(s):
+
+## Expected vs Actual
+Expected:
+Actual:
+
+## Suggested fix

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,14 @@
+---
+name: Enhancement
+labels: enhancement
+about: Propose a content or process improvement
+---
+
+## Proposal
+What and why?
+
+## Where it fits
+Course(s)/module(s):
+
+## Impact
+Beginner/Intermediate/Advanced?

--- a/.github/ISSUE_TEMPLATE/quaterly_review.md
+++ b/.github/ISSUE_TEMPLATE/quaterly_review.md
@@ -1,0 +1,27 @@
+---
+name: Quarterly Review
+labels: quarterly-review
+about: Run the quarterly review checklist for a course or the whole repo
+---
+
+## Scope
+Course/Workshop:
+
+## Tooling Versions
+- rustc:
+- solana:
+- anchor:
+
+## Results
+- Demos run: ✅/❌
+- Notes parity: ✅/❌
+- Links checked: ✅/❌
+- Feedback reviewed: ✅/❌
+
+## Actions
+- [ ] Fix commands in README
+- [ ] Update slides/notes
+- [ ] Replace dead links
+- [ ] Tag release vYYYY-QX
+
+Notes:

--- a/.github/workshop_pull_request_template.md
+++ b/.github/workshop_pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+- [ ] Slides updated / added (Google Slides link)
+- [ ] Facilitator notes updated (speaker notes in slides)
+- [ ] Code demo updated (path):
+- [ ] README updated (objectives, steps, resources)
+- [ ] Maintenance: versions / links / dates refreshed
+
+## Motivation
+Why this change now? Anchor/Solana updates, feedback, or new guidance.
+
+## Testing
+- [ ] Demo builds & deploys on devnet/local
+- [ ] Commands validated
+- [ ] Notes align with actual outputs
+
+## Screens / Links
+- Slides:
+- Repo paths:
+
+## Checklist
+- [ ] No UI/CPI in 1h Anchor session (as scoped)
+- [ ] Security = audit mindset + resources
+- [ ] “What’s Next” points to PDAs, testing, security, IDL→TS client
+- [ ] Linked issues (if any):

--- a/courses/MAINTENANCE.md
+++ b/courses/MAINTENANCE.md
@@ -1,0 +1,80 @@
+# Curriculum Maintenance Guide
+
+This guide defines how the Solana Foundation curriculum is kept accurate, discoverable, and credible over time.
+
+---
+
+## 1) Quarterly Review (every Mar/Jun/Sep/Dec)
+
+**Goal:** validate code, fix drift, refresh links, and publish a tagged release.
+
+**Owners:** Curriculum Maintainers (@guibibeau @resourcefulmind)
+
+**Checklist**
+- [ ] **Tooling sanity:** `rustc --version`, `solana --version`, `anchor --version`
+- [ ] **Run demos/workshops:** each course’s canonical demo builds, deploys (devnet or local), tests pass
+- [ ] **Notes parity:** facilitator notes reflect current outputs & commands
+- [ ] **Links:** run link checker CI; replace dead/outdated references
+- [ ] **Feedback intake:** review last quarter’s survey results + GitHub issues labeled `feedback` or `quarterly-review`
+- [ ] **Roadmap triage:** decide what ships now vs. next quarter
+- [ ] **Tag release:** `vYYYY-QX` and update root README “Last reviewed” date and supported toolchain versions
+
+**Release notes (CHANGELOG.md)**
+- Breaking changes (commands, APIs)
+- Updated materials (slides/notes/code)
+- New/retired modules
+
+---
+
+## 2) Distribution & Ratings
+
+**Discovery**
+- List each course/workshop on the curriculum index/site with:
+  - Title, 1-line pitch, duration, level
+  - Slides link (Google Slides), code repo path, last reviewed date
+  - Stable tag (e.g., `v2025-Q3`)
+
+**Ratings & Feedback**
+- After each delivery, facilitators share the **SURVEY.md** link (Google Form)
+- Aggregate results each quarter; flag items <3/5 for priority fixes
+- Create issues with label `feedback` referencing survey data
+
+---
+
+## 3) Incomplete Courses
+
+- **Draft labeling:** mark clearly as **Draft** in README + course plan
+- **Placement:** keep drafts in `draft/` or a branch; don’t list on discovery page as “stable”
+- **Graduation criteria:** (a) 1 successful pilot delivery, (b) notes complete, (c) passes quarterly review
+
+---
+
+## 4) Versioning & Tooling
+
+- **Tag each quarterly release:** `vYYYY-QX`
+- **Record toolchain versions** in each course README (e.g., `Anchor CLI vX.Y.Z`, `Solana CLI v1.19.x`)
+- **Pin examples** where needed; if APIs change, bump the tag and note migration
+- **Deprecation:** archive obsolete courses to `archive/` with a deprecation note
+
+---
+
+## 5) Governance & Roles
+
+- **Maintainers:** own the quarterly review and merge gates
+- **Contributors:** submit PRs; follow templates; add repro steps for code changes
+- **Issue labels:** `quarterly-review`, `feedback`, `content-bug`, `enhancement`, `draft`, `good-first-issue`
+
+---
+
+## 6) Quality Bar (apply to every workshop)
+
+- Slides header-only (unless a graphic is essential)
+- Complete facilitator notes (timing, prompts, pitfalls, curriculum links)
+- Runnable code demo with minimal friction (devnet or local)
+- Security: audit mindset guidance and links (e.g., Rektoff roadmap)
+- Clear “What’s Next” path into the broader curriculum
+
+---
+
+**Next scheduled review:** _2026-01-15_  
+**Last reviewed:** _2025-09-24_  

--- a/courses/SURVEY.md
+++ b/courses/SURVEY.md
@@ -1,0 +1,11 @@
+# Post-Session Survey (Facilitators → Learners)
+
+Use a simple form (Google) with:
+- Overall rating (1–5)
+- Confidence increase (Before vs After)
+- Hardest part
+- What to change or add
+- Would you recommend this session?
+
+Maintainers: aggregate responses each quarter and tag issues `feedback`.
+Survey link: https://your-form-link


### PR DESCRIPTION
### Summary
Introduces maintenance and governance scaffolding for the curriculum repo.

### What’s included
- **MAINTENANCE.md:** Defines quarterly review process, discovery & ratings, incomplete courses, versioning, and roles
- **.github templates:** PR template + issue templates for quarterly reviews, content bugs, and enhancements
- **CI:** Link checker workflow to catch dead references in Markdown
- **SURVEY.md:** Template for facilitator → learner feedback (survey link placeholder)
- **Root README:** “Last reviewed” + stable release tag reference

### Why
Supports request for a structured maintenance process:
- **Quarterly reviews** to ensure code runs and materials stay fresh
- **Discovery & ratings** for visibility and feedback
- **Versioning & tagging** for clarity (e.g., `v2025-Q3`)
- **Governance scaffolding** so contributors and maintainers have clear processes

### Next Steps
- Set “Next scheduled review” date in MAINTENANCE.md
- Add actual survey form link in SURVEY.md
- Tag release `v2025-Q3` after merge to mark first stable version
